### PR TITLE
Optimise binary builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ hashbrown = "0.1.8"
 rayon = "1.0.3"
 signal-hook = "0.1.8"
 structopt = "0.2.14"
+
+[dev-dependencies]
+assert_cmd = "0.11.0"
 predicates = "1.0.0"
 
 [profile.release]
 lto = true
-overflow-checks = false
-
-[dev-dependencies]
-assert_cmd = "0.11.0"
+codegen-units = 1

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ $(TEST_FILE): top-1m.csv
 
 $(TMP_DIR):
 	# create a 100MB RAM disk for benchmarking
-	diskutil partitionDisk $(hdiutil attach -nomount ram://204800) 1 GPTFormat APFS 'ramdisk' '100%'
+	diskutil partitionDisk $$(hdiutil attach -nomount ram://204800) 1 GPTFormat APFS 'ramdisk' '100%'
 
 top-1m.csv:
 	curl -s -o $@.zip https://s3.amazonaws.com/alexa-static/top-1m.csv.zip
@@ -26,8 +26,8 @@ bench-unix: $(TEST_FILE)
 	hyperfine --style basic --warmup 1 "gsort --parallel=4 $< | uniq -c | gsort --parallel=4 -k1,1 -rn | head -n 10"
 
 bench-awk: $(TEST_FILE)
-	hyperfine -m 20 --style basic --warmup 3 "gawk -f test/utils/pattern.awk $(TEST_FILE) | head -n 10"
+	hyperfine -m 100 --style basic --warmup 3 "gawk -f tests/utils/pattern.awk $(TEST_FILE) | head -n 10"
 
 bench-bin: $(TEST_FILE)
 	cargo build --release && \
-	hyperfine -m 20 --style basic --warmup 3 "target/release/count --top 10 $<"
+	hyperfine -m 100 --style basic --warmup 3 "target/release/count --top 10 $<"

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ An anecdotal benchmark: Count the top-level domains of the Alexa top 1 million w
 make benchmark
 ```
 
-| Tool        | Time [ms] |
-| ----------- | --------: |
-| rusty count |       136 |
-| awk         |       207 |
-| unix tools  |      4101 |
+| Tool                  | Time [ms] |
+| --------------------- | --------: |
+| rusty count (LTO)     |       124 |
+| rusty count (default) |       150 |
+| awk                   |       207 |
+| unix tools            |      4101 |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,11 +36,11 @@ pub struct Config {
             case_insensitive = "true"
         )
     )]
-    pub sort_by: SortingOrder,
+    sort_by: SortingOrder,
     #[structopt(long = "top")]
-    pub top: Option<usize>,
+    top: Option<usize>,
     #[structopt()]
-    pub input: Option<String>,
+    input: Option<String>,
 }
 
 pub fn run(config: Config) -> Result<(), Error> {
@@ -117,22 +117,28 @@ fn watch_sig_pipe() -> Result<Arc<AtomicBool>, Error> {
     Ok(sig_pipe)
 }
 
-#[test]
-fn test_sort_counts_by_key() {
-    let mut input = vec![(&"b", &3), (&"c", &2), (&"a", &1)];
-    let output = vec![(&"a", &1), (&"b", &3), (&"c", &2)];
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    sort_counts(&mut input, &SortingOrder::Key);
+    #[test]
+    fn test_sort_counts_by_key() {
+        let mut input = vec![(&"b", &3), (&"c", &2), (&"a", &1)];
+        let output = vec![(&"a", &1), (&"b", &3), (&"c", &2)];
 
-    assert_eq!(input, output);
-}
+        sort_counts(&mut input, &SortingOrder::Key);
 
-#[test]
-fn test_sort_counts_by_counts() {
-    let mut input = vec![(&"c", &2), (&"a", &1), (&"b", &3)];
-    let output = vec![(&"b", &3), (&"c", &2), (&"a", &1)];
+        assert_eq!(input, output);
+    }
 
-    sort_counts(&mut input, &SortingOrder::Count);
+    #[test]
+    fn test_sort_counts_by_counts() {
+        let mut input = vec![(&"c", &2), (&"a", &1), (&"b", &3)];
+        let output = vec![(&"b", &3), (&"c", &2), (&"a", &1)];
 
-    assert_eq!(input, output);
+        sort_counts(&mut input, &SortingOrder::Count);
+
+        assert_eq!(input, output);
+    }
+
 }


### PR DESCRIPTION
- Move unit tests into a separate module
- Reduce codegen-unit parameters which yields better optimisation
- Fix build steps in Makefile
- Increase lower bound of benchmarking runs
- Update benchmarking results